### PR TITLE
Notes about wasm

### DIFF
--- a/assembly/index.cc
+++ b/assembly/index.cc
@@ -12,11 +12,7 @@ void saxpy(const v8::FunctionCallbackInfo<v8::Value>& info) {
 
   int i;
 
-  if (n < 0) {
-    return;
-  }
-
-  if (alpha == 0) {
+  if (!alpha || n < 0) {
     return;
   }
 
@@ -24,7 +20,7 @@ void saxpy(const v8::FunctionCallbackInfo<v8::Value>& info) {
     int m = n % 4;
     if (m != 0) {
       for (i = 0; i < m; i++) {
-        y[i] = y[i] + alpha * x[i];
+        y[i] += alpha * x[i];
       }
     }
 
@@ -32,8 +28,8 @@ void saxpy(const v8::FunctionCallbackInfo<v8::Value>& info) {
       return;
     }
 
-    for (i = 0; i < n; i += 4) {
-      y[i] = y[i] + alpha * x[i];
+    for (i = m; i < n; i += 4) {
+      y[i + 0] = y[i + 0] + alpha * x[i + 0];
       y[i + 1] = y[i + 1] + alpha * x[i + 1];
       y[i + 2] = y[i + 2] + alpha * x[i + 2];
       y[i + 3] = y[i + 3] + alpha * x[i + 3];

--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -1,4 +1,3 @@
-import 'allocator/tlsf';
-
+import 'allocator/arena';
 export { memory };
 export { saxpy } from './saxpy';

--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -1,3 +1,3 @@
 import 'allocator/arena';
 export { memory };
-export { saxpy } from './saxpy';
+export { empty, saxpy } from './saxpy';

--- a/assembly/saxpy.js
+++ b/assembly/saxpy.js
@@ -1,10 +1,7 @@
 "use strict";
 exports.__esModule = true;
 function saxpy(n, alpha, x, incx, y, incy) {
-    if (n < 0) {
-        return;
-    }
-    if (alpha === 0) {
+    if (!alpha || n < 0) {
         return;
     }
     var i;
@@ -12,14 +9,14 @@ function saxpy(n, alpha, x, incx, y, incy) {
         var m = n % 4;
         if (m !== 0) {
             for (i = 0; i < m; i++) {
-                y[i] = y[i] + alpha * x[i];
+                y[i] += alpha * x[i];
             }
         }
         if (n < 4) {
             return;
         }
         for (i = m; i < n; i += 4) {
-            y[i] += alpha * x[i];
+            y[i + 0] += alpha * x[i + 0];
             y[i + 1] += alpha * x[i + 1];
             y[i + 2] += alpha * x[i + 2];
             y[i + 3] += alpha * x[i + 3];
@@ -29,15 +26,15 @@ function saxpy(n, alpha, x, incx, y, incy) {
         var ix = 1;
         var iy = 1;
         if (incx < 0) {
-            ix = (-n) * incx;
+            ix = (1 - n) * incx;
         }
         if (incy < 0) {
-            iy = (-n) * incy;
+            iy = (1 - n) * incy;
         }
         for (i = 0; i < n; i++) {
             y[iy] = y[i] + alpha * x[ix];
-            ix = ix + incx;
-            iy = iy + incy;
+            ix += incx;
+            iy += incy;
         }
     }
 }

--- a/assembly/saxpy.ts
+++ b/assembly/saxpy.ts
@@ -11,7 +11,7 @@ export function saxpy(n: i32, alpha: f32, x: Float32Array, incx: i32, y: Float32
     let m = n % 4;
     if (m) {
       for (i = 0; i < m; i++) {
-        unchecked(y[i] = unchecked(y[i]) + alpha * unchecked(x[i]));
+        y.__unchecked_set(i, y.__unchecked_get(i) + alpha * x.__unchecked_get(i));
       }
     }
 
@@ -20,10 +20,10 @@ export function saxpy(n: i32, alpha: f32, x: Float32Array, incx: i32, y: Float32
     }
 
     for (i = m; i < n; i += 4) {
-      y[i + 0] = unchecked(y[i + 0]) + alpha * unchecked(x[i + 0]);
-      y[i + 1] = unchecked(y[i + 1]) + alpha * unchecked(x[i + 1]);
-      y[i + 2] = unchecked(y[i + 2]) + alpha * unchecked(x[i + 2]);
-      y[i + 3] = unchecked(y[i + 3]) + alpha * unchecked(x[i + 3]);
+      y.__unchecked_set(i + 0, y.__unchecked_get(i + 0) + alpha * x.__unchecked_get(i + 0));
+      y.__unchecked_set(i + 1, y.__unchecked_get(i + 1) + alpha * x.__unchecked_get(i + 1));
+      y.__unchecked_set(i + 2, y.__unchecked_get(i + 2) + alpha * x.__unchecked_get(i + 2));
+      y.__unchecked_set(i + 3, y.__unchecked_get(i + 3) + alpha * x.__unchecked_get(i + 3));
     }
   } else {
     let ix = 1;
@@ -38,7 +38,7 @@ export function saxpy(n: i32, alpha: f32, x: Float32Array, incx: i32, y: Float32
     }
 
     for (i = 0; i < n; i++) {
-      unchecked(y[iy] = unchecked(y[i]) + alpha * unchecked(x[ix]));
+      y.__unchecked_set(iy, y.__unchecked_get(i) + alpha * x.__unchecked_get(ix));
       ix += incx;
       iy += incy;
     }

--- a/assembly/saxpy.ts
+++ b/assembly/saxpy.ts
@@ -1,19 +1,13 @@
 export function saxpy(n: i32, alpha: f32, x: Float32Array, incx: i32, y: Float32Array, incy: i32): void {
-  if (n < 0) {
-    return;
-  }
-
-  if (alpha === 0) {
-    return;
-  }
+  if (!alpha || n < 0) return;
 
   let i: i32;
 
   if (incx === 1 && incy === 1) {
     let m = n % 4;
-    if (m !== 0) {
+    if (m) {
       for (i = 0; i < m; i++) {
-        y[i] = y[i] + alpha * x[i];
+        unchecked(y[i] = unchecked(y[i]) + alpha * unchecked(x[i]));
       }
     }
 
@@ -22,27 +16,27 @@ export function saxpy(n: i32, alpha: f32, x: Float32Array, incx: i32, y: Float32
     }
 
     for (i = m; i < n; i += 4) {
-      y[i] += alpha * x[i];
-      y[i + 1] += alpha * x[i + 1];
-      y[i + 2] += alpha * x[i + 2];
-      y[i + 3] += alpha * x[i + 3];
+      y[i + 0] = unchecked(y[i + 0]) + alpha * unchecked(x[i + 0]);
+      y[i + 1] = unchecked(y[i + 1]) + alpha * unchecked(x[i + 1]);
+      y[i + 2] = unchecked(y[i + 2]) + alpha * unchecked(x[i + 2]);
+      y[i + 3] = unchecked(y[i + 3]) + alpha * unchecked(x[i + 3]);
     }
   } else {
     let ix = 1;
     let iy = 1;
 
     if (incx < 0) {
-      ix = (-n) * incx;
+      ix = (1 - n) * incx;
     }
 
     if (incy < 0) {
-      iy = (-n) * incy;
+      iy = (1 - n) * incy;
     }
 
     for (i = 0; i < n; i++) {
-      y[iy] = y[i] + alpha * x[ix];
-      ix = ix + incx;
-      iy = iy + incy;
+      unchecked(y[iy] = unchecked(y[i]) + alpha * unchecked(x[ix]));
+      ix += incx;
+      iy += incy;
     }
   }
 }

--- a/assembly/saxpy.ts
+++ b/assembly/saxpy.ts
@@ -1,3 +1,7 @@
+
+export function empty(n: i32, alpha: f32, x: Float32Array, incx: i32, y: Float32Array, incy: i32): void {
+}
+
 export function saxpy(n: i32, alpha: f32, x: Float32Array, incx: i32, y: Float32Array, incy: i32): void {
   if (!alpha || n < 0) return;
 

--- a/index.ts
+++ b/index.ts
@@ -10,25 +10,27 @@ const wasm = loader.instantiateBuffer(readFileSync('./index.wasm'));
 
 const c = require('./build/Release/addon');
 
-const vx = Vector.random(512, -1, 1, Float32Array);
-const vy = Vector.random(512, -1, 1, Float32Array);
+const size = 512 * 4;
 
-const x = Vector.random(512, -1, 1, Float32Array).data as Float32Array;
-const y = Vector.random(512, -1, 1, Float32Array).data as Float32Array;
+const vx = Vector.random(size, -1, 1, Float32Array);
+const vy = Vector.random(size, -1, 1, Float32Array);
+
+const x = Vector.random(size, -1, 1, Float32Array).data as Float32Array;
+const y = Vector.random(size, -1, 1, Float32Array).data as Float32Array;
 
 const px = wasm.newArray(x);
 const py = wasm.newArray(y);
 
 suite.add('ts', () => {
-  saxpy(512, 1, x, 1, y, 1);
+  saxpy(size, 1, x, 1, y, 1);
 });
 
 suite.add('wasm', () => {
-  wasm.saxpy(512, 1, px, 1, py, 1);
+  wasm.saxpy(size, 1, px, 1, py, 1);
 });
 
 suite.add('c', () => {
-  c.saxpy(512, 1, x, 1, y, 1);
+  c.saxpy(size, 1, x, 1, y, 1);
 });
 
 suite.add('vectorious', () => {

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ const wasm = loader.instantiateBuffer(readFileSync('./index.wasm'));
 
 const c = require('./build/Release/addon');
 
-const size = 512 * 4;
+const size = 512;
 
 const vx = Vector.random(size, -1, 1, Float32Array);
 const vy = Vector.random(size, -1, 1, Float32Array);
@@ -23,6 +23,10 @@ const py = wasm.newArray(y);
 
 suite.add('ts', () => {
   saxpy(size, 1, x, 1, y, 1);
+});
+
+suite.add('empty', () => {
+  wasm.empty(size, 1, px, 1, py, 1);
 });
 
 suite.add('wasm', () => {

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ const wasm = loader.instantiateBuffer(readFileSync('./index.wasm'));
 
 const c = require('./build/Release/addon');
 
-const size = 512;
+const size = 512 * 1024 * 30;
 
 const vx = Vector.random(size, -1, 1, Float32Array);
 const vy = Vector.random(size, -1, 1, Float32Array);
@@ -20,6 +20,7 @@ const y = Vector.random(size, -1, 1, Float32Array).data as Float32Array;
 
 const px = wasm.newArray(x);
 const py = wasm.newArray(y);
+
 
 suite.add('ts', () => {
   saxpy(size, 1, x, 1, y, 1);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npx ts-node index.ts",
-    "build": "node-gyp rebuild && asc assembly/index.ts -b index.wasm -t index.wat -O3 --sourceMap --validate --noAssert"
+    "build": "node-gyp rebuild && asc assembly/index.ts -b index.wasm -t index.wat -O3 --validate --noAssert"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npx ts-node index.ts",
-    "build": "node-gyp rebuild && asc assembly/index.ts -b index.wasm -t index.wat --sourceMap --validate --debug"
+    "build": "node-gyp rebuild && asc assembly/index.ts -b index.wasm -t index.wat -O3 --sourceMap --validate --noAssert"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Results for `size = 512`:
```
ts x 1,716,407 ops/sec ±0.31% (95 runs sampled)
empty x 59,527,333 ops/sec ±0.41% (93 runs sampled)
wasm x 283,926 ops/sec ±0.57% (96 runs sampled)
c x 2,914,992 ops/sec ±0.31% (91 runs sampled)
vectorious x 6,565,008 ops/sec ±0.24% (94 runs sampled)
```

where `empty` is just stub:
```ts
export function empty(n: i32, alpha: f32, x: Float32Array, incx: i32, y: Float32Array, incy: i32): void {
}
```

As you can see Wasm has a pretty high overhead during `host <-> wasm` call. So using `benchmark.js` which call tested function many times is not good idea. Also found issue when AS doesn't inline buffer's `get`/`set` which add a lot of overhead on wasm side as well. It looks like some regression for latest build ([created issue for that](https://github.com/AssemblyScript/assemblyscript/issues/515)). So I manually switch to `__unchecked_get`/`__unchecked_set`.

Results for `size = 512 * 1024 * 30`:
```
ts x 39.17 ops/sec ±0.92% (51 runs sampled)
empty x 56,761,025 ops/sec ±0.22% (94 runs sampled)
wasm x 15.25 ops/sec ±0.53% (41 runs sampled)
c x 81.14 ops/sec ±2.06% (69 runs sampled)
vectorious x 102 ops/sec ±1.04% (73 runs sampled)
```